### PR TITLE
Fix decoding to larger output buffer

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -381,7 +381,11 @@ impl<R: Reader> Decoder<R> {
         if unlikely(buf.len() < size) {
             return Err(Error::OutputBufferTooSmall { size: buf.len(), required: size });
         }
-        self.reader.decode_image(buf, self.channels.as_u8(), self.header.channels.as_u8())?;
+        self.reader.decode_image(
+            &mut buf[..size],
+            self.channels.as_u8(),
+            self.header.channels.as_u8(),
+        )?;
         Ok(size)
     }
 


### PR DESCRIPTION
`decode_impl_stream` expects the output buffer to be of the size of the decoded content.

Fixes:
https://github.com/aldanor/qoi-rust/issues/18