### PR TITLE
decode: fix transparent background bug 

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -35,6 +35,11 @@ where
     let mut px = Pixel::<N>::new().with_a(0xff);
     let mut px_rgba: Pixel<4>;
 
+    if matches!(data, [QOI_OP_RUN..=QOI_OP_RUN_END, ..]) {
+        px_rgba = px.as_rgba(0xff);
+        index[px_rgba.hash_index() as usize] = px_rgba;
+    }
+
     while let [px_out, ptail @ ..] = pixels {
         pixels = ptail;
         match data {
@@ -60,8 +65,6 @@ where
                 phead.fill(px.into());
                 pixels = ptail;
                 data = dtail;
-                px_rgba = px.as_rgba(0xff);
-                index[px_rgba.hash_index() as usize] = px_rgba;
                 continue;
             }
             [b1 @ QOI_OP_DIFF..=QOI_OP_DIFF_END, dtail @ ..] => {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -60,6 +60,8 @@ where
                 phead.fill(px.into());
                 pixels = ptail;
                 data = dtail;
+                px_rgba = px.as_rgba(0xff);
+                index[px_rgba.hash_index() as usize] = px_rgba;
                 continue;
             }
             [b1 @ QOI_OP_DIFF..=QOI_OP_DIFF_END, dtail @ ..] => {
@@ -178,6 +180,7 @@ where
                 let (phead, ptail) = pixels.split_at_mut(run); // can't panic
                 phead.fill(px.into());
                 pixels = ptail;
+                index[px.hash_index() as usize] = px;
                 continue;
             }
             QOI_OP_DIFF..=QOI_OP_DIFF_END => {

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), allow(unused_imports, dead_code))]
 
 use qoi::{
-    consts::{QOI_OP_RGB, QOI_OP_RUN},
+    consts::{QOI_OP_INDEX, QOI_OP_RGB, QOI_OP_RUN},
     decode_to_vec, Channels, ColorSpace, Decoder, Header, Result,
 };
 
@@ -59,6 +59,18 @@ fn test_start_with_qoi_op_run() -> Result<()> {
     qoi_data.push(1);
     let (_, decoded) = decode_to_vec(&qoi_data)?;
     assert_eq!(decoded, vec![0, 0, 0, 255, 0, 0, 0, 255, 10, 20, 30, 255]);
+    Ok(())
+}
+
+#[test]
+fn test_start_with_qoi_op_run_and_use_index() -> Result<()> {
+    let header = Header::try_new(4, 1, Channels::Rgba, ColorSpace::Linear)?;
+    let mut qoi_data: Vec<_> = header.encode().into_iter().collect();
+    qoi_data.extend([QOI_OP_RUN | 1, QOI_OP_RGB, 10, 20, 30, QOI_OP_INDEX | 53]);
+    qoi_data.extend([0; 7]);
+    qoi_data.push(1);
+    let (_, decoded) = decode_to_vec(&qoi_data)?;
+    assert_eq!(decoded, vec![0, 0, 0, 255, 0, 0, 0, 255, 10, 20, 30, 255, 0, 0, 0, 255]);
     Ok(())
 }
 


### PR DESCRIPTION
This PR fixes qoi-rust#16 where the instructions [RUN 1, RGB r g b,
INDEX 53] produced [Black, rgb, Transparent] instead of [Black, rgb,
Black]. 53 is the hash of (0, 0, 0, 255) and in the special case where
the first instruction is RUN it needs to store the color in the index so
that future INDEX instructions can fetch the value. This is only needed
if the first instruction is RUN.

Since this is only needed for the first instruction one could probably
handle this edgecase before the loop. If that is something we want, we
can either modify this PR or you can make a new one with a better
solution.