### PR TITLE
 RFE: encoder: add stride & various raw input formats support #11 

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -10,13 +10,16 @@ use crate::consts::{QOI_HEADER_SIZE, QOI_OP_INDEX, QOI_OP_RUN, QOI_PADDING, QOI_
 use crate::error::{Error, Result};
 use crate::header::Header;
 use crate::pixel::{Pixel, SupportedChannels};
-use crate::types::{Channels, ColorSpace};
+use crate::types::{Channels, ColorSpace, RawChannels};
 #[cfg(feature = "std")]
 use crate::utils::GenericWriter;
 use crate::utils::{unlikely, BytesMut, Writer};
 
 #[allow(clippy::cast_possible_truncation, unused_assignments, unused_variables)]
-fn encode_impl<W: Writer, const N: usize>(mut buf: W, data: &[u8]) -> Result<usize>
+fn encode_impl<W: Writer, const N: usize, const R: usize>(
+    mut buf: W, data: &[u8], width: usize, height: usize, stride: usize,
+    read_px: impl Fn(&mut Pixel<N>, &[u8]),
+) -> Result<usize>
 where
     Pixel<N>: SupportedChannels,
     [u8; N]: Pod,
@@ -30,57 +33,55 @@ where
     let mut px = Pixel::<N>::new().with_a(0xff);
     let mut index_allowed = false;
 
-    let n_pixels = data.len() / N;
+    let n_pixels = width * height;
 
-    for (i, chunk) in data.chunks_exact(N).enumerate() {
-        px.read(chunk);
-        if px == px_prev {
-            run += 1;
-            if run == 62 || unlikely(i == n_pixels - 1) {
-                buf = buf.write_one(QOI_OP_RUN | (run - 1))?;
-                run = 0;
-            }
-        } else {
-            if run != 0 {
-                #[cfg(not(feature = "reference"))]
-                {
-                    // credits for the original idea: @zakarumych (had to be fixed though)
-                    buf = buf.write_one(if run == 1 && index_allowed {
-                        QOI_OP_INDEX | hash_prev
-                    } else {
-                        QOI_OP_RUN | (run - 1)
-                    })?;
-                }
-                #[cfg(feature = "reference")]
-                {
+    let mut i = 0;
+    for row in data.chunks(stride).take(height) {
+        let pixel_row = &row[..width * R];
+        for chunk in pixel_row.chunks_exact(R) {
+            read_px(&mut px, chunk);
+            if px == px_prev {
+                run += 1;
+                if run == 62 || unlikely(i == n_pixels - 1) {
                     buf = buf.write_one(QOI_OP_RUN | (run - 1))?;
+                    run = 0;
                 }
-                run = 0;
-            }
-            index_allowed = true;
-            let px_rgba = px.as_rgba(0xff);
-            hash_prev = px_rgba.hash_index();
-            let index_px = &mut index[hash_prev as usize];
-            if *index_px == px_rgba {
-                buf = buf.write_one(QOI_OP_INDEX | hash_prev)?;
             } else {
-                *index_px = px_rgba;
-                buf = px.encode_into(px_prev, buf)?;
+                if run != 0 {
+                    #[cfg(not(feature = "reference"))]
+                    {
+                        // credits for the original idea: @zakarumych (had to be fixed though)
+                        buf = buf.write_one(if run == 1 && index_allowed {
+                            QOI_OP_INDEX | hash_prev
+                        } else {
+                            QOI_OP_RUN | (run - 1)
+                        })?;
+                    }
+                    #[cfg(feature = "reference")]
+                    {
+                        buf = buf.write_one(QOI_OP_RUN | (run - 1))?;
+                    }
+                    run = 0;
+                }
+                index_allowed = true;
+                let px_rgba = px.as_rgba(0xff);
+                hash_prev = px_rgba.hash_index();
+                let index_px = &mut index[hash_prev as usize];
+                if *index_px == px_rgba {
+                    buf = buf.write_one(QOI_OP_INDEX | hash_prev)?;
+                } else {
+                    *index_px = px_rgba;
+                    buf = px.encode_into(px_prev, buf)?;
+                }
+                px_prev = px;
             }
-            px_prev = px;
+            i += 1;
         }
     }
 
+    assert_eq!(i, n_pixels);
     buf = buf.write_many(&QOI_PADDING)?;
     Ok(cap.saturating_sub(buf.capacity()))
-}
-
-#[inline]
-fn encode_impl_all<W: Writer>(out: W, data: &[u8], channels: Channels) -> Result<usize> {
-    match channels {
-        Channels::Rgb => encode_impl::<_, 3>(out, data),
-        Channels::Rgba => encode_impl::<_, 4>(out, data),
-    }
 }
 
 /// The maximum number of bytes the encoded image will take.
@@ -116,11 +117,14 @@ pub fn encode_to_vec(data: impl AsRef<[u8]>, width: u32, height: u32) -> Result<
 /// Encode QOI images into buffers or into streams.
 pub struct Encoder<'a> {
     data: &'a [u8],
+    stride: usize,
+    raw_channels: RawChannels,
     header: Header,
 }
 
 impl<'a> Encoder<'a> {
     /// Creates a new encoder from a given array of pixel data and image dimensions.
+    /// The data must be in RGB(A) order, without fill borders (extra stride).
     ///
     /// The number of channels will be inferred automatically (the valid values
     /// are 3 or 4). The color space will be set to sRGB by default.
@@ -136,7 +140,32 @@ impl<'a> Encoder<'a> {
             return Err(Error::InvalidImageLength { size, width, height });
         }
         header.channels = Channels::try_from(n_channels.min(0xff) as u8)?;
-        Ok(Self { data, header })
+        let raw_channels = RawChannels::from(header.channels);
+        let stride = width as usize * raw_channels.bytes_per_pixel();
+        Ok(Self { data, stride, raw_channels, header })
+    }
+
+    /// Creates a new encoder from a given array of pixel data, image
+    /// dimensions, stride, and raw format.
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new_raw(
+        data: &'a (impl AsRef<[u8]> + ?Sized), width: u32, height: u32, stride: usize,
+        raw_channels: RawChannels,
+    ) -> Result<Self> {
+        let data = data.as_ref();
+        let channels = raw_channels.into();
+        let header = Header::try_new(width, height, channels, ColorSpace::default())?;
+
+        if stride < width as usize * raw_channels.bytes_per_pixel() {
+            return Err(Error::InvalidStride { stride });
+        }
+        let size = data.len();
+        if stride * (height - 1) as usize + width as usize * raw_channels.bytes_per_pixel() < size {
+            return Err(Error::InvalidImageLength { size, width, height });
+        }
+
+        Ok(Self { data, stride, raw_channels, header })
     }
 
     /// Returns a new encoder with modified color space.
@@ -181,7 +210,7 @@ impl<'a> Encoder<'a> {
         }
         let (head, tail) = buf.split_at_mut(QOI_HEADER_SIZE); // can't panic
         head.copy_from_slice(&self.header.encode());
-        let n_written = encode_impl_all(BytesMut::new(tail), self.data, self.header.channels)?;
+        let n_written = self.encode_impl_all(BytesMut::new(tail))?;
         Ok(QOI_HEADER_SIZE + n_written)
     }
 
@@ -203,8 +232,62 @@ impl<'a> Encoder<'a> {
     #[inline]
     pub fn encode_to_stream<W: Write>(&self, writer: &mut W) -> Result<usize> {
         writer.write_all(&self.header.encode())?;
-        let n_written =
-            encode_impl_all(GenericWriter::new(writer), self.data, self.header.channels)?;
+        let n_written = self.encode_impl_all(GenericWriter::new(writer))?;
         Ok(n_written + QOI_HEADER_SIZE)
+    }
+
+    #[inline]
+    fn encode_impl_all<W: Writer>(&self, out: W) -> Result<usize> {
+        let width = self.header.width as usize;
+        let height = self.header.height as usize;
+        let stride = self.stride;
+        match self.raw_channels {
+            RawChannels::Rgb => {
+                encode_impl::<_, 3, 3>(out, self.data, width, height, stride, Pixel::read)
+            }
+            RawChannels::Bgr => {
+                encode_impl::<_, 3, 3>(out, self.data, width, height, stride, |px, c| {
+                    px.update_rgb(c[2], c[1], c[0]);
+                })
+            }
+            RawChannels::Rgba => {
+                encode_impl::<_, 4, 4>(out, self.data, width, height, stride, Pixel::read)
+            }
+            RawChannels::Argb => {
+                encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
+                    px.update_rgba(c[1], c[2], c[3], c[0]);
+                })
+            }
+            RawChannels::Rgbx => {
+                encode_impl::<_, 3, 4>(out, self.data, width, height, stride, |px, c| {
+                    px.read(&c[..3]);
+                })
+            }
+            RawChannels::Xrgb => {
+                encode_impl::<_, 3, 4>(out, self.data, width, height, stride, |px, c| {
+                    px.update_rgb(c[1], c[2], c[3]);
+                })
+            }
+            RawChannels::Bgra => {
+                encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
+                    px.update_rgba(c[2], c[1], c[0], c[3]);
+                })
+            }
+            RawChannels::Abgr => {
+                encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
+                    px.update_rgba(c[3], c[2], c[1], c[0]);
+                })
+            }
+            RawChannels::Bgrx => {
+                encode_impl::<_, 3, 4>(out, self.data, width, height, stride, |px, c| {
+                    px.update_rgb(c[2], c[1], c[0]);
+                })
+            }
+            RawChannels::Xbgr => {
+                encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
+                    px.update_rgb(c[3], c[2], c[1]);
+                })
+            }
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     UnexpectedBufferEnd,
     /// Invalid stream end marker encountered when decoding
     InvalidPadding,
+    /// Invalid stride
+    InvalidStride { stride: usize },
     #[cfg(feature = "std")]
     /// Generic I/O error from the wrapped reader/writer
     IoError(std::io::Error),
@@ -56,6 +58,9 @@ impl Display for Error {
             }
             Self::InvalidPadding => {
                 write!(f, "invalid padding (stream end marker mismatch)")
+            }
+            Self::InvalidStride { stride } => {
+                write!(f, "invalid stride: {stride}")
             }
             #[cfg(feature = "std")]
             Self::IoError(ref err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use crate::decode::{decode_header, decode_to_buf, Decoder};
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use crate::encode::encode_to_vec;
-pub use crate::encode::{encode_max_len, encode_to_buf, Encoder};
+pub use crate::encode::{encode_max_len, encode_to_buf, Encoder, EncoderBuilder};
 
 pub use crate::error::{Error, Result};
 pub use crate::header::Header;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,4 +92,4 @@ pub use crate::encode::{encode_max_len, encode_to_buf, Encoder};
 
 pub use crate::error::{Error, Result};
 pub use crate::header::Header;
-pub use crate::types::{Channels, ColorSpace};
+pub use crate::types::{Channels, ColorSpace, RawChannels};

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -5,6 +5,7 @@ use bytemuck::{cast, Pod};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(transparent)]
+// in RGBA order
 pub struct Pixel<const N: usize>([u8; N]);
 
 impl<const N: usize> Pixel<N> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -111,3 +111,58 @@ impl TryFrom<u8> for Channels {
         }
     }
 }
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum RawChannels {
+    Rgb,
+    Bgr,
+    Rgba,
+    Argb,
+    Rgbx,
+    Xrgb,
+    Bgra,
+    Abgr,
+    Bgrx,
+    Xbgr,
+}
+
+impl From<Channels> for RawChannels {
+    fn from(value: Channels) -> Self {
+        match value {
+            Channels::Rgb => Self::Rgb,
+            Channels::Rgba => Self::Rgba,
+        }
+    }
+}
+
+impl From<RawChannels> for Channels {
+    fn from(value: RawChannels) -> Self {
+        match value {
+            RawChannels::Rgb
+            | RawChannels::Bgr
+            | RawChannels::Rgbx
+            | RawChannels::Xrgb
+            | RawChannels::Bgrx
+            | RawChannels::Xbgr => Self::Rgb,
+            RawChannels::Rgba | RawChannels::Argb | RawChannels::Bgra | RawChannels::Abgr => {
+                Self::Rgba
+            }
+        }
+    }
+}
+
+impl RawChannels {
+    pub(crate) const fn bytes_per_pixel(self) -> usize {
+        match self {
+            Self::Rgb | Self::Bgr => 3,
+            Self::Rgba
+            | Self::Argb
+            | Self::Rgbx
+            | Self::Xrgb
+            | Self::Bgra
+            | Self::Abgr
+            | Self::Bgrx
+            | Self::Xbgr => 4,
+        }
+    }
+}

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -97,57 +97,96 @@ fn test_new_encoder() {
         Err(Error::InvalidImageLength { size: 12, width: 3, height: 3 })
     ));
 
-    assert!(matches!(qoi::Encoder::new(&arr3, 1, 1), Err(Error::InvalidChannels { channels: 12 })));
+    assert!(matches!(
+        qoi::Encoder::new(&arr3, 1, 1),
+        Err(Error::InvalidImageLength { size: 12, width: 1, height: 1 })
+    ));
 
-    let enc = qoi::Encoder::new_raw(&arr3, 2, 2, 2 * 3, RawChannels::Bgr).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr3, 2, 2)
+        .stride(2 * 3)
+        .raw_channels(RawChannels::Bgr)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgb);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, [2, 1, 0, 5, 4, 3, 8, 7, 6, 11, 10, 9]);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Rgba).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Rgba)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgba);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, arr4);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Bgra).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Bgra)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgba);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, [2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15]);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Rgbx).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Rgbx)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgb);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14]);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Xrgb).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Xrgb)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgb);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Bgra).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Bgra)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgba);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, [2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15]);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Abgr).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Abgr)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgba);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12]);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Bgrx).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Bgrx)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgb);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();
     assert_eq!(res, [2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12]);
 
-    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Xbgr).unwrap();
+    let enc = qoi::EncoderBuilder::new(&arr4, 2, 2)
+        .stride(2 * 4)
+        .raw_channels(RawChannels::Xbgr)
+        .build()
+        .unwrap();
     assert_eq!(enc.channels(), Channels::Rgb);
     let qoi = enc.encode_to_vec().unwrap();
     let (_header, res) = decode_to_vec(qoi).unwrap();

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -44,7 +44,7 @@ fn test_decode_stream_to_larger_buffer() -> Result<()> {
 }
 
 #[test]
-fn test_new_encoder() {
+fn test_new_decoder() {
     // this used to fail due to `Bytes` not being `pub`
     let arr = [0u8];
     let _ = qoi::Decoder::new(&arr[..]);

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -2,7 +2,7 @@
 
 use qoi::{
     consts::{QOI_OP_INDEX, QOI_OP_RGB, QOI_OP_RUN},
-    decode_to_vec, Channels, ColorSpace, Decoder, Header, Result,
+    decode_to_vec, Channels, ColorSpace, Decoder, Error, Header, RawChannels, Result,
 };
 
 const ONE_PIXEL_QOI_IMAGE: [u8; 23] = [
@@ -79,4 +79,77 @@ fn test_start_with_qoi_op_run_and_use_index() -> Result<()> {
 fn test_big_endian() {
     // so we can see it in the CI logs
     assert_eq!(u16::to_be_bytes(1), [0, 1]);
+}
+
+#[test]
+fn test_new_encoder() {
+    let arr3 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]; // 2 * 2 * 3
+    let arr4 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]; // 2 * 2 * 4
+
+    let enc = qoi::Encoder::new(&arr3, 2, 2).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgb);
+
+    let enc = qoi::Encoder::new(&arr4, 2, 2).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgba);
+
+    assert!(matches!(
+        qoi::Encoder::new(&arr3, 3, 3),
+        Err(Error::InvalidImageLength { size: 12, width: 3, height: 3 })
+    ));
+
+    assert!(matches!(qoi::Encoder::new(&arr3, 1, 1), Err(Error::InvalidChannels { channels: 12 })));
+
+    let enc = qoi::Encoder::new_raw(&arr3, 2, 2, 2 * 3, RawChannels::Bgr).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgb);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [2, 1, 0, 5, 4, 3, 8, 7, 6, 11, 10, 9]);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Rgba).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgba);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, arr4);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Bgra).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgba);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15]);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Rgbx).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgb);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14]);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Xrgb).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgb);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Bgra).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgba);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15]);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Abgr).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgba);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12]);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Bgrx).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgb);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12]);
+
+    let enc = qoi::Encoder::new_raw(&arr4, 2, 2, 2 * 4, RawChannels::Xbgr).unwrap();
+    assert_eq!(enc.channels(), Channels::Rgb);
+    let qoi = enc.encode_to_vec().unwrap();
+    let (_header, res) = decode_to_vec(qoi).unwrap();
+    assert_eq!(res, [3, 2, 1, 7, 6, 5, 11, 10, 9, 15, 14, 13]);
 }


### PR DESCRIPTION


The input format is not necessarily RGB or RGBA, and doing a pre-pass conversion can be quite costly (adding about 15-20% of total time from empirical study)

For simplicity reasons, I made sure not to break the existing API.

Those changes don't seem to affect the encoder performance in a significant way.
